### PR TITLE
Remove font size percentage changes from html tag, introduce rem func…

### DIFF
--- a/src/app/components/pages/api-page/api-page.component.scss
+++ b/src/app/components/pages/api-page/api-page.component.scss
@@ -9,9 +9,9 @@
 }
 
 .api__table {
-  padding: 2.5rem 2.5rem;
+  padding: rem(25) rem(25);
   border: 1px solid $hackney-black;
-  margin-bottom: 4rem;
+  margin-bottom: rem(40);
 }
 
 .api__table__header {
@@ -29,7 +29,7 @@
     align-items: flex-start;
 
     & p:first-child {
-      margin-right: .5rem;
+      margin-right: rem(5);
     }
   }
 }
@@ -45,7 +45,7 @@
     justify-content: space-between;
     align-content: center;
 
-    padding-top: 2.5rem;
+    padding-top: rem(25);
 
     // &:not(:last-child) {
     //   border-bottom: 1px solid $hackney-black;
@@ -61,7 +61,7 @@
     text-align: right;
 
     & p:first-child {
-      margin-right: .5rem;
+      margin-right: rem(5);
     }
   }
 
@@ -71,7 +71,7 @@
 
   &__section {
     border-bottom: 1px solid $hackney-black;
-    padding-bottom: 2.5rem;
+    padding-bottom: rem(25);
   }
 
 }
@@ -79,11 +79,11 @@
 .api__details {
 
   &__overview {
-    margin-bottom: 4rem;
+    margin-bottom: rem(40);
   }
 
   &__compliance {
-    margin-bottom: 4rem;
+    margin-bottom: rem(40);
   }
 
   &__compliance__header {
@@ -96,7 +96,7 @@
   }
 
   &__compliance__tag {
-    margin-top: 1.3rem;
+    margin-top: rem(13);
   }
 
   &__compliance__text {
@@ -139,14 +139,14 @@
   }
 
   .api__details__overview {
-    margin-bottom: 1.5rem;
+    margin-bottom: rem(15);
   }
 }
 
 .api__table__body__link {
   text-decoration: none;
   font-family: inherit;
-  font-size: 1.6rem;
+  font-size: rem(16);
   font-weight: 600;
   color: $hackney-blue;
 

--- a/src/app/components/pages/home/home.component.scss
+++ b/src/app/components/pages/home/home.component.scss
@@ -13,15 +13,15 @@
     }
 
     &-list {
-        padding-left: 2rem;
-        margin-bottom: 2.5rem;
+        padding-left: rem(20);
+        margin-bottom: rem(25);
 
         &__item {
 
         }
 
         &__item:not(:last-child) {
-            margin-bottom: .7rem;
+            margin-bottom: rem(7);
         }
     }
 
@@ -30,8 +30,8 @@
         width: 100%;
         height: auto;
         display: inline-block;
-        margin-top: 2rem;
-        margin-bottom: 4rem;
+        margin-top: rem(20);
+        margin-bottom: rem(40);
     }
 }
 

--- a/src/app/components/pages/swagger-endpoint-page/swagger-endpoint-page.component.scss
+++ b/src/app/components/pages/swagger-endpoint-page/swagger-endpoint-page.component.scss
@@ -9,7 +9,7 @@
 }
 
 .endpoint__text {
-    margin: 2rem 0;
+    margin: rem(20) 0;
 }
 
 .endpoint__medium__tag {
@@ -17,7 +17,7 @@
 }
 
 .endpoint__medium__uri {
-    margin: 0 2rem;
+    margin: 0 rem(20);
     
     & a {
         color: $hackney-blue;
@@ -26,7 +26,7 @@
 
 .endpoint__medium__box {
     display: flex;
-    margin: 4rem 0;
+    margin: rem(40) 0;
 }
 
 .endpoint__table__title {
@@ -38,14 +38,14 @@
     flex-direction: column;
     justify-content: flex-start;
 
-    margin: 3rem 0;
+    margin: rem(30) 0;
 }
 
 .endpoint__table__row {
     display: flex;
     align-items: center;
 
-    padding: 1.5rem 0;
+    padding: rem(15) 0;
     border-bottom: 1px solid $hackney-black;
 }
 

--- a/src/app/components/partials/admin-manage-keys/admin-manage-keys.component.html
+++ b/src/app/components/partials/admin-manage-keys/admin-manage-keys.component.html
@@ -1,35 +1,3 @@
-<div class="admin__box">
-  <div class="admin__header">
-    <div class="admin__header__email">
-      <h3 class="heading-medium">Email</h3>
-    </div>
-    <div class="admin__header__api">
-      <h3 class="heading-medium">API ID</h3>
-    </div>
-    <div class="admin__header__stage">
-      <h3 class="heading-medium">Stage</h3>
-    </div>
-  </div>
-
-  <div class="admin__body">
-    <div class="admin__row" *ngIf="!tokenObjects || tokenObjects.length < 1">
-      <p> There are no API keys to verify</p>
-    </div>
-
-    <div class="admin__row">
-      <div *ngFor="let tokenObject of tokenObjects" class="admin__row__item">
-        <p class="paragraph-text__small admin__row__email" scope="row">{{tokenObject.email}}</p>
-        <p class="paragraph-text__small admin__row__api">{{tokenObject.apiID}}</p>
-        <p class="paragraph-text__small admin__row__stage">{{tokenObject.stage}}</p>
-        <div class="admin__row__button">
-          <a class="hackney-button" (click)="verifyUser(tokenObject)" type="button">Verify</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- 
 <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
@@ -43,12 +11,12 @@
     <tbody class="govuk-table__body">
       
       <tr *ngFor="let tokenObject of tokenObjects"  class="govuk-table__row">
-        <td class="govuk-table__cell" scope="row">{{tokenObject.email}}</td>
-        <td class="govuk-table__cell">{{tokenObject.apiID}}</td>
-        <td class="govuk-table__cell">{{tokenObject.stage}}</td>
-        <td class="govuk-table__cell">
-            <a class="govuk-button govuk-button--start" (click)="verifyUser(tokenObject)" type="button">Verify</a>
+        <td data-label="Email" class="govuk-table__cell" scope="row">{{tokenObject.email}}</td>
+        <td data-label="API ID" class="govuk-table__cell">{{tokenObject.apiID}}</td>
+        <td data-label="Stage" class="govuk-table__cell">{{tokenObject.stage}}</td>
+        <td class="govuk-table__cell govuk-table__cell--no-header">
+            <a class="govuk-button" (click)="verifyUser(tokenObject)" type="button">Verify</a>
         </td>
       </tr>
     </tbody>
-  </table> -->
+  </table>

--- a/src/app/components/partials/admin-manage-keys/admin-manage-keys.component.scss
+++ b/src/app/components/partials/admin-manage-keys/admin-manage-keys.component.scss
@@ -1,8 +1,8 @@
 @import '../../../../styles.scss';
 
 .admin__box {
-    margin-top: 4rem;
-    margin-bottom: 4rem;
+    margin-top: rem(40);
+    margin-bottom: rem(40);
     display: flex;
     flex-direction: column;
 }
@@ -29,7 +29,7 @@
     display: flex;
     flex-direction: column;
 
-    padding: 2rem 0;
+    padding: rem(20) 0;
 }
 
 .admin__row {
@@ -67,6 +67,10 @@
     border-bottom: 1px solid $hackney-black;
 }
 
+.govuk-table .govuk-button {
+    margin-bottom: 0;
+}
+
 @media screen and (max-width: 640px) {
     .admin__box {
         margin-top: 0;
@@ -78,8 +82,8 @@
         justify-content: flex-start;
         align-items: flex-start;
         
-        padding-bottom: 1.5rem;
-        margin-bottom: 1.5rem;
+        padding-bottom: rem(15);
+        margin-bottom: rem(15);
     }
 
     .hackney-button {
@@ -92,5 +96,35 @@
 
     .admin__row__button {
         margin-bottom: 1rem;
+    }
+
+    .govuk-table__head {
+        display: none;
+    }
+
+    .govuk-table__cell {
+        border-bottom: 0;
+        display: block;
+        padding: 3px 0;
+
+        &:before {
+            content: attr(data-label);
+            display: inline-block;
+            font-weight: bold;
+            width: rem(50);
+        }
+
+        &--no-header {
+            border-bottom: 1px solid $hackney-light-grey;
+            margin-bottom: rem(10);
+        }
+
+        &--no-header:before {
+            content: none;
+        }
+    }
+
+    .govuk-table .govuk-button {
+        margin-bottom: rem(10);
     }
 }

--- a/src/app/components/partials/alert/alert.component.scss
+++ b/src/app/components/partials/alert/alert.component.scss
@@ -2,7 +2,7 @@
 
 .alert__banner {
   text-align: center;
-  padding: 2rem;
+  padding: rem(20);
   border: 4px solid transparent;
   margin: 4rem 0;
 
@@ -26,6 +26,6 @@
 
 @media screen and (min-width: 740px) {
   .alert__banner {
-    margin: 2rem 0;
+    margin: rem(20) 0;
   }
 }

--- a/src/app/components/partials/api-form/api-form.component.scss
+++ b/src/app/components/partials/api-form/api-form.component.scss
@@ -6,7 +6,7 @@
 // @import '../../../../../node_modules/govuk-frontend/components/label/label';
 
 .apiform_container {
-    padding: 5rem 3rem;
+    padding: rem(50) rem(30);
 }
 
 .apiform__api {
@@ -16,15 +16,15 @@
 }
 
 .apiform__api__form {
-    margin-bottom: 2rem;
+    margin-bottom: rem(20);
 }
 
 .apiform__api__form--formgroup {
-    margin-bottom: 2rem;
+    margin-bottom: rem(20);
 }
 
 .apiform__api__label {
-    font-size: 1.8rem;
+    font-size: rem(18);
     font-weight: 400;
     font-family: inherit;
 }
@@ -36,5 +36,5 @@
 }
 
 .textarea {
-    margin-bottom: 2rem;
+    margin-bottom: rem(20);
 }

--- a/src/app/components/partials/api-item-crud/api-item-crud.component.scss
+++ b/src/app/components/partials/api-item-crud/api-item-crud.component.scss
@@ -5,7 +5,7 @@
   justify-content: space-between;
   align-items: center;
 
-  padding: 1.5rem;
+  padding: rem(15);
   border-bottom: 1px solid $hackney-black;
 
 }

--- a/src/app/components/partials/api-item/api-item.component.scss
+++ b/src/app/components/partials/api-item/api-item.component.scss
@@ -2,8 +2,8 @@
 
 .api__item__container {
 
-  padding: 2rem;
-  margin-bottom: 3rem;
+  padding: rem(20);
+  margin-bottom: rem(30);
   border-bottom: 2px solid $hackney-black;
 }
 
@@ -13,7 +13,7 @@
   justify-content: space-between;
   align-items: flex-start;
 
-  margin-bottom: 3rem;
+  margin-bottom: rem(30);
 
   &__title {
     
@@ -34,7 +34,7 @@
 
     & p:first-child {
       display: inline-block;
-      margin-right: .5rem;
+      margin-right: rem(5);
     }
   }
 }

--- a/src/app/components/partials/footer/footer.component.scss
+++ b/src/app/components/partials/footer/footer.component.scss
@@ -44,7 +44,7 @@
 
 .footer {
     background-color: $hackney-black;
-    height: 20rem;
+    height: rem(200);
 
     &__items {
         display: flex;
@@ -57,7 +57,7 @@
         &-link:visited {
             text-decoration: none;
             color: $hackney-white;
-            font-size: 1.8rem;
+            font-size: rem(18);
             padding: .3rem .5rem;
             
         }
@@ -74,7 +74,7 @@
 @media (max-width: 780px) {
     
     .footer {
-        height: 30rem;
+        height: rem(240);
     }
     
     .footer__items {
@@ -83,7 +83,7 @@
         align-items: flex-start;
 
         & a {
-            margin: .8rem 0;
+            margin: rem(6.4) 0;
         }
     }
 }

--- a/src/app/components/partials/header/header.component.scss
+++ b/src/app/components/partials/header/header.component.scss
@@ -1,6 +1,5 @@
-@import "../../../../assets/sass/abstracts/variables";
+@import '../../../../styles.scss';
 
-@import "../../../../assets/sass/utilities/hackney-stripes";
 .container {
   display: flex;
   flex-direction: column;
@@ -26,15 +25,15 @@
   &__hackney-logo {
     display: inline-block;
     align-self: flex-start;
-    margin-bottom: 1rem;
+    margin-bottom: rem(10);
   }
 
   &__hackney-image {
-    height: 3.5rem;
+    height: rem(35);
     width: auto;
 
     @media (min-width: 830px) {
-      height: 4.5rem;
+      height: rem(45);
     }
   }
 
@@ -42,11 +41,11 @@
   // NAVBAR
 
   &__navbar {
-    padding-bottom: 1rem;
+    padding-bottom: rem(10);
     width: 100%;
 
     @media (min-width: 830px) { 
-      margin-top: 1.6rem;
+      margin-top: rem(16);
       padding: 0;
       width: auto;
     }
@@ -59,14 +58,14 @@
       justify-content: space-between;
 
       color: $hackney-white;
-      font-size: 1.8rem;
+      font-size: rem(18);
     }
 
     &-list li > a {
       text-decoration: none;
       color: inherit;
 
-      padding: 1rem;
+      padding: rem(10);
       cursor: pointer;
       border: 3px solid transparent;
 
@@ -76,7 +75,7 @@
     &-btn-login {
       color: inherit;
       transition: all 0.2s;
-      padding: 0.5rem;
+      padding: rem(5);
     }
 
     &-list li a:hover,
@@ -110,25 +109,25 @@
   flex-direction: column;
   color: $hackney-white;
   background: $hackney-black;
-  margin: 1rem 0;
+  margin: rem(10) 0;
 
   &:not(:last-child) {
-    margin-bottom: 2.5rem;
+    margin-bottom: rem(25);
   }
 }
 
 
 .dropdown__content__item {
   display: inline-block;
-  padding: .5 .7rem;
+  padding: rem(5) rem(7);
 }
 
 .dropdown__arrow {
   display: inline-block;
   transition: all .2s;
-  font-size: 2.2rem;
-  line-height: 2.2rem;
-  margin-left: 1rem;
+  font-size: rem(22);
+  line-height: rem(22);
+  margin-left: rem(10);
 }
 
 .dropdown__arrow--rotate {
@@ -152,11 +151,11 @@
   .header__navbar-list {
 
     flex-direction: column;
-    margin-left: -1rem;
+    margin-left: rem(-8);
 
    & li {
     
-    margin: 1rem 0;
+    margin: rem(10) 0;
    }
     
   }

--- a/src/app/components/partials/spinner/spinner.component.scss
+++ b/src/app/components/partials/spinner/spinner.component.scss
@@ -1,15 +1,15 @@
-@import '../../../../assets/sass/abstracts/variables';
+@import '../../../../styles.scss';
 
 .loader,
 .loader:after {
   border-radius: 50%;
-  width: 7rem;
-  height: 7rem;
+  width: rem(70);
+  height: rem(70);
 
 
   @media (max-width: 900px) {
-    width: 5.5rem;
-    height: 5.5rem;
+    width: rem(55);
+    height: rem(55);
     }
 }
 .loader {

--- a/src/app/components/partials/swagger-endpoint-item/swagger-endpoint-item.component.scss
+++ b/src/app/components/partials/swagger-endpoint-item/swagger-endpoint-item.component.scss
@@ -10,11 +10,11 @@
       justify-content: space-between;
       align-items: center;
 
-      padding: 1rem;
-      margin-bottom: 2rem;
+      padding: rem(10);
+      margin-bottom: rem(20);
       border: 1.5px solid $hackney-black;
 
-      box-shadow: 0 1rem 1rem $hackney-light-grey;
+      box-shadow: 0 rem(10) rem(10) $hackney-light-grey;
       transition: all .2s;
 
       &:hover {
@@ -23,7 +23,7 @@
       }
 
       &:active {
-        transform: translateY(.2rem)
+        transform: translateY(#{rem(2)})
       }
 
     }
@@ -52,17 +52,17 @@
       justify-content: space-between;
       
       align-items: center;
-      padding: .5rem 1rem;
+      padding: rem(5) rem(10);
 
       border-bottom: 1px solid $hackney-black;
 
       &:not(:last-child) {
-        margin-bottom: 1.5rem;
+        margin-bottom: rem(15);
         
       }
 
       &:last-child {
-        margin-bottom: 3rem;
+        margin-bottom: rem(30);
       }
 
       &-endpoint {

--- a/src/assets/sass/abstracts/_typography.scss
+++ b/src/assets/sass/abstracts/_typography.scss
@@ -3,19 +3,19 @@
     font-family: $font-family;
     font-weight: 400;
 
-    font-size: 1.8rem;
+    font-size: rem(18);
     line-height: 1.6;
     margin-top: 0;
     padding-bottom: $margin-bottom-text;
 
     &__small {
-        font-size: 1.6rem;
+        font-size: rem(16);
     }
 }
 
 .heading-large {
     color: $hackney-black;
-    font-size: 3.5rem;
+    font-size: rem(35);
     font-family: $font-family;
     font-weight: 700;
     margin-bottom: $margin-bottom-heading;
@@ -24,14 +24,14 @@
 .heading-huge {
     color: $hackney-black;
     font-family: $font-family;
-    font-size: 5rem;
+    font-size: rem(50);
     font-weight: 700;
     margin-bottom: $margin-bottom-heading;
 }
 
 .heading-medium {
     color: $hackney-black;
-    font-size: 2.5rem;
+    font-size: rem(25);
     font-family: $font-family;
     font-weight: 700;
     margin-bottom: $margin-bottom-heading;
@@ -39,7 +39,7 @@
 
 .heading-small {
     color: $hackney-black;
-    font-size: 2rem;
+    font-size: rem(20);
     font-family: $font-family;
     font-weight: 700;
     margin-bottom: $margin-bottom-heading;
@@ -61,16 +61,16 @@
 @media screen and (max-width: 740px) {
     
     .heading-huge {
-        font-size: 4.5rem;
+        font-size: rem(36);
     }
 }
 
 @media screen and (max-width: 680px) {
     .heading-huge {
-        font-size: 3.8rem;
+        font-size: rem(30);
     }
 
     .heading-large {
-        font-size: 3rem;
+        font-size: rem(24);
     }
 }

--- a/src/assets/sass/abstracts/_variables.scss
+++ b/src/assets/sass/abstracts/_variables.scss
@@ -15,7 +15,7 @@ $hackney-border-color: #064579;
 
 $page-header-bg-colour: $hackney-black;
 $page-header-text-colour: $hackney-white;
-$page-header-padding: 2rem !default;
+$page-header-padding: rem(20) !default;
 
 $swagger-method-delete: 	#df3034;
 $swagger-method-put-patch: #f47738;
@@ -40,14 +40,14 @@ $dark-stripe-width: $hackney-stripe-width * 2;
 $middle-stripe-style: $middle-stripe-width solid $hackney-stripes-middle-colour;
 
 ////// BOXING
-$container-padding: 4.5rem 4.5rem;
-$container-padding-mobile: 2.25rem 2.25rem;
-$margin-bottom-heading: 2rem;
-$margin-bottom-text: 1.5rem;
+$container-padding: rem(45) rem(45);
+$container-padding-mobile: rem(22.5) rem(22.5);
+$margin-bottom-heading: rem(20);
+$margin-bottom-text: rem(15);
 
 ///// TYPO
-$heading--big: 5rem;
-$heading--medium: 2.5rem;
+$heading--big: rem(50);
+$heading--medium: rem(25);
 
 $font-family: "nta", Arial, sans-serif;
 
@@ -58,7 +58,7 @@ $font-family: "nta", Arial, sans-serif;
     font-family: $font-family;
     font-weight: 400;
 
-    font-size: 1.8rem;
+    font-size: rem(18);
     line-height: 1.6;
     margin-top: 0;
     padding-bottom: $margin-bottom-text;

--- a/src/assets/sass/base/_base.scss
+++ b/src/assets/sass/base/_base.scss
@@ -14,7 +14,6 @@ html {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    font-size: 62.5%;
     font-family: "nta", Arial, sans-serif;
 }
 
@@ -22,15 +21,9 @@ body {
     font-weight: 400;
     line-height: 1.6;
     min-height: 100vh;
-    font-size: 1.8rem;
+    font-size: rem(18);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
     background-color: $hackney-background;
-}
-
-@media screen and (max-width: 740px) {
-    html {
-        font-size: 50%;
-    }
 }

--- a/src/assets/sass/utilities/_functions.scss
+++ b/src/assets/sass/utilities/_functions.scss
@@ -1,0 +1,7 @@
+@function rem($size) {
+  @if (unitless($size)) {
+    $size: $size * 1px;
+  }
+  $remSize: $size / 16px;
+  @return #{$remSize}rem;
+}

--- a/src/assets/sass/utilities/_reusable.scss
+++ b/src/assets/sass/utilities/_reusable.scss
@@ -14,7 +14,7 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 700;
-    font-size: 1.6rem;
+    font-size: rem(16);
     line-height: 1.1875;
 }
 
@@ -39,18 +39,18 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 400;
-    font-size: 1.6rem;
+    font-size: rem(16);
     line-height: 1.1875;
 
     box-sizing: border-box;
     display: inline-block;
 
-    margin: 2rem 0;
-    padding: .7rem 1rem;
+    margin: rem(20) 0;
+    padding: rem(7) rem(10);
     border-radius: 0;
     color: $hackney-white;
     background-color: $hackney-green;
-    box-shadow: 0 .4rem .3rem #bbb;
+    box-shadow: 0 rem(4) rem(3) #bbb;
 
     text-align: center;
     vertical-align: top;
@@ -64,7 +64,7 @@
     }
 
     &:active {
-        transform: translateY(.2rem) scale(0.99);   
+        transform: translateY(#{rem(2)}) scale(0.99);   
     }
 
     &:disabled {
@@ -88,9 +88,9 @@
     width: 100%;
     height: auto;
     padding: 15px 10px;
-    margin-bottom: 2rem;
+    margin-bottom: rem(20);
 
-    font-size: 1.8rem;
+    font-size: rem(18);
 
     &:focus,
     &:active {
@@ -138,7 +138,7 @@
 //// FORMS
 
 .form-group--error {
-    padding-left: 1.5rem;
+    padding-left: rem(15);
     border-left: 5px solid #b10e1e;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+@import "assets/sass/utilities/functions";
 @import "assets/sass/abstracts/variables";
 @import "assets/sass/abstracts/typography";
 


### PR DESCRIPTION
…tion for easy calculations, add responsive tables

I've removed font size percentage reductions on the html tag so that the base rems is always 16px. This means that the GDS components that we're incorporating will appear at the correct size: 

<img width="885" alt="Screenshot 2019-06-14 at 10 01 39" src="https://user-images.githubusercontent.com/50906992/59497548-97ce7880-8e8b-11e9-9116-d2bd81093306.png">

I've added in a new rem function in sass to allow us to make easy dev calculations from pixel size to rems. I've implemented this across the codebase, so where we were previously using `XXrem` I have replaced this with `rem(15)` for example (this would achieve a sizing of the rem equivalent of 15px).

I've also re-introduced the govuk table component and added in a responsive solution so that it works better on smaller screens:

Mobile:

<img width="344" alt="Screenshot 2019-06-14 at 10 01 58" src="https://user-images.githubusercontent.com/50906992/59497715-debc6e00-8e8b-11e9-8986-49702a837e10.png">

Desktop:

<img width="904" alt="Screenshot 2019-06-14 at 10 01 51" src="https://user-images.githubusercontent.com/50906992/59497704-d9f7ba00-8e8b-11e9-8c98-c213a2cc2b4f.png">
